### PR TITLE
Removing the sending of Base64 attachment contents.

### DIFF
--- a/backend/amsterdam-email-api/src/main/kotlin/com/ritense/valtimoplugins/amsterdam/emailapi/client/Attachment.kt
+++ b/backend/amsterdam-email-api/src/main/kotlin/com/ritense/valtimoplugins/amsterdam/emailapi/client/Attachment.kt
@@ -6,5 +6,6 @@ data class Attachment (
     val disposition: String,
     val filename: String?,
     val contentType: String?,
-    val href: URI
+    val href: URI,
+    val content: String? = null
 )

--- a/backend/amsterdam-email-api/src/main/kotlin/com/ritense/valtimoplugins/amsterdam/emailapi/client/Attachment.kt
+++ b/backend/amsterdam-email-api/src/main/kotlin/com/ritense/valtimoplugins/amsterdam/emailapi/client/Attachment.kt
@@ -5,7 +5,6 @@ import java.net.URI
 data class Attachment (
     val disposition: String,
     val filename: String?,
-    val content: String?,
     val contentType: String?,
     val href: URI
 )

--- a/backend/amsterdam-email-api/src/main/kotlin/com/ritense/valtimoplugins/amsterdam/emailapi/plugin/EmailApiPlugin.kt
+++ b/backend/amsterdam-email-api/src/main/kotlin/com/ritense/valtimoplugins/amsterdam/emailapi/plugin/EmailApiPlugin.kt
@@ -163,16 +163,10 @@ class EmailApiPlugin(
                 logger.debug { "adding attachment: " +  informatieObject.bestandsnaam}
 
                 val downloadURI = URI(informatieObject.url.toString().plus("/download"))
-                val content = restClient
-                    .get()
-                    .uri(downloadURI)
-                    .retrieve()
-                    .body<ByteArray>()!!
 
-                val attachment: Attachment = Attachment(
+                val attachment = Attachment(
                     ATTACHMENT,
                     informatieObject.bestandsnaam,
-                    Base64.getEncoder().encodeToString(content),
                     informatieObject.formaat,
                     downloadURI
                 )


### PR DESCRIPTION
Due to the email component now ignoring the the attachment contents (and instead using the downloadURI that is passed), we can save some bandwidth by not passing the Base64 encoded attachments.